### PR TITLE
[FIX] : 추천검색어 범위를 벗어나서도 키보드 이벤트가 발생하는 문제를 해결합니다다

### DIFF
--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -27,10 +27,11 @@ export default function SearchBar() {
   };
 
   const onKeyDownHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const maxLength = recommendItems.slice(0, 10).length;
     if (e.key === 'ArrowDown') {
-      setCurrentIdx(prevIdx => prevIdx + 1);
+      setCurrentIdx(prevIdx => (prevIdx === maxLength - 1 ? maxLength - 1 : prevIdx + 1));
     } else if (e.key === 'ArrowUp') {
-      setCurrentIdx(prevIdx => prevIdx - 1);
+      setCurrentIdx(prevIdx => (prevIdx === 0 ? 0 : prevIdx - 1));
     }
   };
 


### PR DESCRIPTION
## 🐣 개요
-  추천검색어 범위를 벗어나서도 키보드 이벤트가 발생하는 문제를 해결합니다
## 🐣 작업사항
- 받아온 추천 검색어 데이터배열의 길이를 10개 이하로 slice한 뒤,해당 길이 이내에서만 `currentIdx` 가 유효하도록 범위를 좁힙니다. 
